### PR TITLE
修复构建错误：移除 console.log 并优化 ESLint 配置允许 console.error/warn

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -59,7 +59,10 @@ export default [
       'no-unused-vars': 'error', // 禁止出现未使用的变量
 
       // 代码质量
-      'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off', // 生产环境禁止 console
+      // 生产环境禁止 console.log，但允许 console.error 和 console.warn（用于错误日志）
+      'no-console': process.env.NODE_ENV === 'production' 
+        ? ['error', { allow: ['warn', 'error'] }] 
+        : 'off',
       'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off', // 生产环境禁止 debugger
       'no-unused-expressions': 'warn', // 禁止出现未使用的表达式
       'no-unreachable': 'error', // 禁止在 return、throw、continue、break 后出现不可达代码

--- a/src/directives/permission.js
+++ b/src/directives/permission.js
@@ -76,8 +76,8 @@ function handlePermission(el, binding, isMounted) {
       resetElement(el)
     }
   } catch (error) {
-    console.error('[v-permission] 权限检查出错:', error)
     // 出错时默认隐藏元素，避免权限泄露
+    console.error('[v-permission] 权限检查出错:', error)
     hideElement(el)
   }
 }

--- a/src/views/log/adminLogin.vue
+++ b/src/views/log/adminLogin.vue
@@ -153,7 +153,6 @@ import { usePermission } from '@/composables/usePermission'
 // ==================== 权限相关 ====================
 const { getButtonInfoFull } = usePermission()
 const detailButtonInfo = getButtonInfoFull('adminLoginLog:detail')
-console.log(detailButtonInfo)
 
 // ==================== 工具函数 ====================
 /**


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Disables console.log in production (allowing warn/error) and removes a debug log from the admin login view.
> 
> - **ESLint**:
>   - Update `no-console` to error on `console.log` in production while allowing `console.warn` and `console.error`.
> - **Log Admin View (`src/views/log/adminLogin.vue`)**:
>   - Remove stray `console.log(detailButtonInfo)`.
> - **Permission Directive (`src/directives/permission.js`)**:
>   - Keep error logging on permission-check failures (call placement adjusted).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ceef5ba5b03da7d25100653f12322aea0bd6766d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->