### PR TITLE
修复 GitHub Pages 部署：添加 enablement 参数

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Setup Pages
         uses: actions/configure-pages@v4
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enable GitHub Pages by adding `enablement: true` to the `configure-pages` step in the deploy workflow.
> 
> - **CI/CD (GitHub Actions)**:
>   - Update `./.github/workflows/deploy.yml` to configure `actions/configure-pages@v4` with `with: enablement: true` in the "Setup Pages" step for GitHub Pages deployment.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cdc0b738d70110a9cb7894d0116e4449a2659822. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->