### PR TITLE
配置 GitHub Pages 部署：分离页面 base 路径和 API 地址，支持从 Secrets 读取配置

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,11 +34,20 @@ jobs:
       - name: Build
         run: npm run build:production
         env:
-          # 设置 base 路径
+          # 页面 base 路径（用于路由和静态资源）
           # 如果是普通仓库，使用 /仓库名称/
           # 如果是 username.github.io 仓库，使用 /
-          # 可以根据需要修改为你的仓库名称
-          VITE_BASE_URL: /${{ github.event.repository.name }}/
+          VITE_APP_BASE: /${{ github.event.repository.name }}/
+          # API 服务器地址（参考 .env.production）
+          # 方式1：使用 GitHub Secrets（推荐）- 在仓库 Settings > Secrets and variables > Actions 中配置
+          # 方式2：直接修改下面的值
+          VITE_BASE_URL: ${{ secrets.VITE_BASE_URL != '' && secrets.VITE_BASE_URL || 'http://112.124.53.17' }}
+          # API 路径前缀（参考 .env.production）
+          VITE_BASE_API: /admin
+          # 静态资源路径（参考 .env.production）
+          VITE_BASE_STATIC: /static
+          # 应用标题（参考 .env.production）
+          VITE_APP_TITLE: X-L-Admin
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,7 +18,8 @@ const autoOpenBrowser = AUTO_OPEN_BROWSER === 'true' || AUTO_OPEN_BROWSER === un
 /** Base 路径（用于 GitHub Pages 部署） */
 // 从环境变量读取，如果未设置则默认为 '/'
 // GitHub Pages 部署时，如果是仓库根目录，使用仓库名称；如果是自定义域名，使用 '/'
-const base = process.env.VITE_BASE_URL || '/'
+// 注意：VITE_APP_BASE 用于页面 base 路径，VITE_BASE_URL 用于 API 地址（两者分开）
+const base = process.env.VITE_APP_BASE || '/'
 
 export default defineConfig({
     // ==================== Base 路径配置 ====================


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Split page base and API URL; update deploy workflow env and Vite config to use `VITE_APP_BASE` and read API host from Secrets.
> 
> - **CI/CD (GitHub Pages)**:
>   - Split page base and API configuration in `.github/workflows/deploy.yml`.
>     - Use `VITE_APP_BASE` for page base (`/${{ github.event.repository.name }}/`).
>     - Use `VITE_BASE_URL` for API host, defaulting to `${{ secrets.VITE_BASE_URL }}` or `http://112.124.53.17`.
>     - Add `VITE_BASE_API: /admin`, `VITE_BASE_STATIC: /static`, and `VITE_APP_TITLE: X-L-Admin` to build env.
> - **Build Config**:
>   - In `vite.config.js`, switch base path to `process.env.VITE_APP_BASE` and clarify separation from `VITE_BASE_URL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0cee07498c79ef27fa57e8c9e9a247904e346232. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->